### PR TITLE
Aleph/world entities fix

### DIFF
--- a/.sbproj
+++ b/.sbproj
@@ -275,6 +275,19 @@
     },
     "Summary": "",
     "Description": "",
-    "Public": false
+    "Public": false,
+    "TickRate": 50,
+    "LaunchConfigs": [
+      {
+        "Name": "My New Config",
+        "GameIdent": "cinemateam.cinema#local",
+        "MapName": "testing/cinema_test_main_01.vmap",
+        "MaxPlayers": 1,
+        "GameSettings": {},
+        "Addons": "",
+        "PreLaunchCommand": "",
+        "PostLaunchCommand": ""
+      }
+    ]
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "code/code.sln"
+}

--- a/code/Properties/launchSettings.json
+++ b/code/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "Cinema": {
       "commandName": "Executable",
       "executablePath": "D:\\SteamLibrary\\steamapps\\common\\sbox\\sbox.exe",
-      "commandLineArgs": "\u002Bdeveloper 1 -w 1920 -h 1080 -noassert -tools"
+      "commandLineArgs": "+developer 1 -w 1920 -h 1080 -noassert -tools",
+      "nativeDebugging": true
     }
   }
 }

--- a/code/code.sln
+++ b/code/code.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cinema", "cinema.csproj", "{AF279D18-6A2B-4109-8C74-238FC935F76C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AF279D18-6A2B-4109-8C74-238FC935F76C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF279D18-6A2B-4109-8C74-238FC935F76C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF279D18-6A2B-4109-8C74-238FC935F76C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF279D18-6A2B-4109-8C74-238FC935F76C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B92BC9BE-8357-41DA-8416-E43F8E6D0346}
+	EndGlobalSection
+EndGlobal

--- a/code/entities/weapons/fnb/Hotdog.cs
+++ b/code/entities/weapons/fnb/Hotdog.cs
@@ -10,6 +10,7 @@ public partial class Hotdog : WeaponBase
     public override void Spawn()
     {
         base.Spawn();
+        Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl");
     }
 
     public override void PrimaryFire()

--- a/code/entities/weapons/fnb/Hotdog.cs
+++ b/code/entities/weapons/fnb/Hotdog.cs
@@ -10,7 +10,6 @@ public partial class Hotdog : WeaponBase
     public override void Spawn()
     {
         base.Spawn();
-        Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl");
     }
 
     public override void PrimaryFire()

--- a/code/entities/weapons/fnb/Nachos.cs
+++ b/code/entities/weapons/fnb/Nachos.cs
@@ -10,6 +10,8 @@ public partial class Nachos : WeaponBase
     public override void Spawn()
     {
         base.Spawn();
+        Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl");
+
     }
 
     public override void PrimaryFire()

--- a/code/entities/weapons/fnb/Nachos.cs
+++ b/code/entities/weapons/fnb/Nachos.cs
@@ -10,8 +10,6 @@ public partial class Nachos : WeaponBase
     public override void Spawn()
     {
         base.Spawn();
-        Model = Model.Load("models/hotdog/w_hotdog_boxed.vmdl");
-
     }
 
     public override void PrimaryFire()
@@ -34,7 +32,7 @@ public partial class Nachos : WeaponBase
             };
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
-            
+
             if (Projectile.AutoRemoveThrown)
                 RemoveFromHolder();
         }

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -13,8 +13,6 @@ public partial class Popcorn : WeaponBase
 {
     public override float PrimaryFireRate => 0.85f;
     public override int BaseUses => 10;
-    private string UniqueId = "popcorn_tub"; // The unique id for the hotdog item
-    private Player Owner;
     public override void Spawn()
     {
         base.Spawn();
@@ -39,7 +37,7 @@ public partial class Popcorn : WeaponBase
             };
 
             projectile.LaunchFromEntityViewpoint(WeaponHolder);
-            
+
             if (Projectile.AutoRemoveThrown)
                 RemoveFromHolder();
         }
@@ -49,10 +47,4 @@ public partial class Popcorn : WeaponBase
     {
     }
 
-    public override void Trigger (Player player)
-    {
-        base.OnUse(player);
-
-        Owner = player;
-    }
 }

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -1,4 +1,11 @@
-﻿using Sandbox;
+﻿using Conna.Inventory;
+using Sandbox;
+using Sandbox.util;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
 
 namespace Cinema;
 
@@ -6,12 +13,11 @@ public partial class Popcorn : WeaponBase
 {
     public override float PrimaryFireRate => 0.85f;
     public override int BaseUses => 10;
-
+    private string UniqueId = "popcorn_tub"; // The unique id for the hotdog item
+    private Player Owner;
     public override void Spawn()
     {
         base.Spawn();
-        WorldModel = Model.Load("models/popcorn_tub/w_popcorn_tub_01.vmdl");
-        
     }
 
     public override void PrimaryFire()
@@ -41,5 +47,12 @@ public partial class Popcorn : WeaponBase
 
     public override void Reload()
     {
+    }
+
+    public override void Trigger (Player player)
+    {
+        base.OnUse(player);
+
+        Owner = player;
     }
 }

--- a/code/entities/weapons/fnb/Popcorn.cs
+++ b/code/entities/weapons/fnb/Popcorn.cs
@@ -10,6 +10,8 @@ public partial class Popcorn : WeaponBase
     public override void Spawn()
     {
         base.Spawn();
+        WorldModel = Model.Load("models/popcorn_tub/w_popcorn_tub_01.vmdl");
+        
     }
 
     public override void PrimaryFire()

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -114,12 +114,13 @@ public partial class CinemaGame
             .Ignore(owner)
             .Size(2)
             .Run();
-
+        // might spawn as an entity prefab. Weird.
         var ent = TypeLibrary.Create<Entity>(entityType);
 
         ent.Position = tr.EndPosition;
+        ent.Spawn();
         // Make the spawned entity face the player who spawned it.
-        ent.Rotation = Rotation.From(new Angles(0, (-owner.AimRay.Forward).EulerAngles.yaw, 0));
+        //ent.Rotation = Rotation.From(new Angles(15, (-owner.AimRay.Forward).EulerAngles.yaw, 15));
     }
 
     [ConCmd.Server("item.give")]
@@ -152,7 +153,7 @@ public partial class CinemaGame
 
         var tr = Trace.Ray(player.EyePosition, player.EyePosition + player.EyeRotation.Forward * 999)
             .Ignore(player)
-            .WorldOnly()
+            .StaticOnly()
             .Run();
 
         client.Pawn.Position = tr.EndPosition;

--- a/code/game/Game.Debug.cs
+++ b/code/game/Game.Debug.cs
@@ -136,6 +136,24 @@ public partial class CinemaGame
         player.Inventory.Give(item);
     }
 
+    // creates a world entity for usable items.
+    [ConCmd.Server("item.create")]
+    public static void CreateItemCMD(string itemId)
+    {
+        if (!ValidateUser(ConsoleSystem.Caller.SteamId)) return;
+
+        if (ConsoleSystem.Caller.Pawn is not Player player) return;
+
+        var item = InventorySystem.CreateItem(itemId);
+        if (item == null) return;
+
+        var entity = new ItemEntity();
+        entity.SetItem(item);
+        entity.Position = player.EyePosition + player.EyeRotation.Forward * 100;
+
+    }
+
+
     [ConCmd.Server("player.bring")]
     public static void BringPlayerCMD(string playerName)
     {

--- a/code/player/Player.Inventory.cs
+++ b/code/player/Player.Inventory.cs
@@ -47,11 +47,13 @@ public partial class Player
     {
         if (instance is not IHandheldItem weapon)
         {
+            Log.Info("Not Handheld Item");
             return;
         }
 
         if (!weapon.Weapon.IsValid())
         {
+            Log.Info("Not valid isWeapon Item");
             return;
         }
 

--- a/code/player/Player.Use.cs
+++ b/code/player/Player.Use.cs
@@ -52,10 +52,12 @@ public partial class Player
                     return;
                 }
 
+
                 if (Using is not IUse usable) return;
 
                 if (usable.OnUse(this))
                     return;
+
 
                 StopUsing();
                 return;

--- a/code/player/Player.Use.cs
+++ b/code/player/Player.Use.cs
@@ -1,3 +1,4 @@
+using Conna.Inventory;
 using Sandbox;
 using Sandbox.UI;
 


### PR DESCRIPTION
Item.create console command allows us to spawn in entities as ItemEntity. ItemEntity is one entity that represents any sort of object that can be picked up. 

ent.create will not work with the inventory system.